### PR TITLE
bugfix/demo-link

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ expect(result).to.equal(givenBooleanValue);
 * [API](./typedoc/README.md)
 
 ## Demo and integration examples:
-You can find integration examples for different frameworks (NodeJS, NestJS, Angular, React) in the demo repository:
-[https://github.com/e-hein/type-injector-lib-demo]()
+You can find integration examples for different frameworks (NodeJS, NestJS, Angular, React) in the demo repository:  
+[https://github.com/e-hein/type-injector-lib-demo](https://github.com/e-hein/type-injector-lib-demo/blob/main/README.md)
 
 ## Motivation
 There are plenty of inject libraries out there. Most of them are part of a larger framework so they are only usable in a browser frontend or a server backend.


### PR DESCRIPTION
change url of demo link

demo link has to use a longer url so it doesn't get truncated because of name overlapping